### PR TITLE
DelegateWikis

### DIFF
--- a/Wikithis.Calls.cs
+++ b/Wikithis.Calls.cs
@@ -245,9 +245,14 @@ namespace Wikithis
 
 					if (nameOfArgument != string.Empty)
 						throw new ArgumentNullException($"Call Error: The {nameOfArgument} argument for the attempted message, \"{message ?? messageOverload.ToString()}\" has returned null.");
-
-					if (Wikis.TryGetValue($"{mod.Name}/{name}", out IWiki value))
+					if (DelegateWikis.TryGetValue(mod, out var delegates) && delegates.pageExists(name))
+					{
+						delegates.openPage(name);
+					}
+					else if (Wikis.TryGetValue($"{mod.Name}/{name}", out IWiki value))
+					{
 						(value as IWiki<object, object>).GetEntry(key).OpenWikiPage(withKeybind.Value);
+					}
 					return success;
 				}
 				else if (seventh.Any(x => x.ToLower() == message) || messageOverload.HasValue && messageOverload.Value == 6)

--- a/Wikithis.Calls.cs
+++ b/Wikithis.Calls.cs
@@ -103,6 +103,10 @@ namespace Wikithis
 				{
 					"OpenCustomWiki"
 				};
+				string[] seventh = new string[]
+				{
+					"DelegateWiki"
+				};
 
 				if (first.Any(x => x.ToLower() == message) || messageOverload.HasValue && messageOverload.Value == 0)
 				{
@@ -246,7 +250,27 @@ namespace Wikithis
 						(value as IWiki<object, object>).GetEntry(key).OpenWikiPage(withKeybind.Value);
 					return success;
 				}
-				else if (messageOverload.HasValue && messageOverload.Value == 6)
+				else if (seventh.Any(x => x.ToLower() == message) || messageOverload.HasValue && messageOverload.Value == 6)
+				{
+					Mod mod = args[index + 0] as Mod;
+					Func<object, bool> noWiki = args[index + 1] as Func<object, bool>;
+					Action<object> action = args[index + 2] as Action<object>;
+
+					string nameOfArgument = string.Empty;
+					if (mod == null)
+						nameOfArgument = nameof(mod);
+					if (noWiki == null)
+						nameOfArgument = nameof(noWiki);
+					if (action == null)
+						nameOfArgument = nameof(action);
+
+					if (nameOfArgument != string.Empty)
+						throw new ArgumentNullException($"Call Error: The {nameOfArgument} argument for the attempted message, \"{message ?? messageOverload.ToString()}\" has returned null.");
+
+					DelegateWikis.Add(mod, (noWiki, action));
+					return success;
+				}
+				else if (messageOverload.HasValue && messageOverload.Value == 7)
 				{
 				}
 				else

--- a/Wikithis.cs
+++ b/Wikithis.cs
@@ -200,7 +200,7 @@ namespace Wikithis
 		}
 
 		internal static void OpenWikiPage(Item item, bool forceCheck = true) {
-			if (DelegateWikis.TryGetValue(item.ModItem?.Mod, out var delegates))
+			if (DelegateWikis.TryGetValue(item.ModItem?.Mod, out var delegates) && delegates.pageExists(item))
 			{
 				delegates.openPage(item);
 			}
@@ -211,7 +211,7 @@ namespace Wikithis
 		}
 
 		internal static void OpenWikiPage(NPC npc, bool forceCheck = true) {
-			if (DelegateWikis.TryGetValue(npc?.ModNPC?.Mod, out var delegates))
+			if (DelegateWikis.TryGetValue(npc?.ModNPC?.Mod, out var delegates) && delegates.pageExists(npc))
 			{
 				delegates.openPage(npc);
 			}

--- a/WikithisItem.cs
+++ b/WikithisItem.cs
@@ -17,6 +17,10 @@ namespace Wikithis
 		{
 			IWiki<Item, int> wiki = Wikithis.Wikis[$"Wikithis/{nameof(ItemWiki)}"] as IWiki<Item, int>;
 			bool wrong = !wiki.IsValid(item.type);
+			if (wrong && Wikithis.DelegateWikis.TryGetValue(item?.ModItem?.Mod, out var delegates) && delegates.pageExists(item))
+			{
+				wrong = false;
+			}
 
 			if (line.Mod == Mod.Name && line.Name == "Wikithis:Wiki")
 			{
@@ -51,6 +55,10 @@ namespace Wikithis
 
 			IWiki<Item, int> wiki = Wikithis.Wikis[$"Wikithis/{nameof(ItemWiki)}"] as IWiki<Item, int>;
 			bool wrong = !wiki.IsValid(item.type);
+			if (wrong && Wikithis.DelegateWikis.TryGetValue(item?.ModItem?.Mod, out var delegates) && delegates.pageExists(item))
+			{
+				wrong = false;
+			}
 
 			string text = Language.GetTextValue($"Mods.{Mod.Name}.Click", Wikithis.TooltipHotkeyString(WikithisSystem.WikiKeybind));
 			if (wrong)


### PR DESCRIPTION
Not the prettiest solution, but that would've been a lot more complicated and required basically a complete rewrite of the mod, whereas this is like 25 lines, basically lets mods tell Wikithis that they have a wiki, but they'll handle everything but the tooltip and keybind.

Technically could have issues with `null` keys replacing the Terraria wiki, but I think if someone adds the mod as a strong dependency and adds functions for `null` they're probably not doing it by accident (i.e. they're probably *trying* to replace the Terraria wiki)